### PR TITLE
#4 - Changes profile url to https to avoid token prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         },
         "Sandpoint Profile": {
             "type": "git",
-            "url": "git@github.com:CuBoulder/sandpoint-d11-profile.git"
+            "url": "https://github.com/CuBoulder/sandpoint-d11-profile"
         },
         "Tiamat Custom Entities": {
             "type": "git",


### PR DESCRIPTION
Switch `profile` repo URL from SSH to HTTPS to avoid GitHub token prompt.

Resolves #4 